### PR TITLE
Fixup specs for ManageIQ/manageiq#18969

### DIFF
--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -13,8 +13,8 @@ module Ansible
 
       def write_password_file
         password_hash = {
-          "^SSH [pP]assword:$"    => auth.password,
-          "^BECOME [pP]assword:$" => auth.become_password
+          "^SSH [pP]assword:"    => auth.password,
+          "^BECOME [pP]assword:" => auth.become_password
         }.delete_blanks
 
         File.write(password_file, password_hash.to_yaml) if password_hash.present?

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -6,7 +6,9 @@ module Ansible
       end
 
       def command_line
-        {:user => auth.userid}.delete_blanks.merge(become_args)
+        {:user => auth.userid}.delete_blanks.merge(become_args).tap do |args|
+          args[:ask_pass] = nil if auth.password.present?
+        end
       end
 
       def write_password_file

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -7,7 +7,7 @@ module Ansible
 
       def command_line
         {:user => auth.userid}.delete_blanks.merge(become_args).tap do |args|
-          args[:ask_pass] = nil if auth.password.present?
+          args.delete(:ask_pass) if auth.password.present?
         end
       end
 

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Ansible::Runner::MachineCredential do
         cred.write_password_file
 
         expect(password_hash).to eq(
-          "^SSH [pP]assword:$"    => "secret",
-          "^BECOME [pP]assword:$" => "othersecret"
+          "^SSH [pP]assword:"    => "secret",
+          "^BECOME [pP]assword:" => "othersecret"
         )
 
         expect(File.read(key_file)).to eq("key_data")
@@ -96,7 +96,7 @@ RSpec.describe Ansible::Runner::MachineCredential do
 
         cred.write_password_file
 
-        expect(password_hash["^SSH [pP]assword:$"]).to eq(password)
+        expect(password_hash["^SSH [pP]assword:"]).to eq(password)
       end
     end
   end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -150,7 +150,7 @@ describe(ServiceAnsiblePlaybook) do
           expect(service.options[:retirement_job_options][:extra_vars]).to eq(
             'var1' => 'default_val1', 'var2' => 'default_val2', 'var3' => 'default_val3'
           )
-          expect(service.options[:retirement_job_options]).not_to have_key(:credential)
+          expect(service.options[:retirement_job_options][:credential]).to eq(credential_0.id)
         end
       end
     end


### PR DESCRIPTION
- "Fixes" `service_ansible_playbook_spec.rb` (unsure if this is correct, please review)
- Changes how `:ask_pass` is handled to allow previous specs to pass
- Updates `"$SSH [pP]assword:"` and `"$BECOME [pP]assword:"` keys in specs to match changes

These changes are meant to either be rebased in as is, or just used as reference for making the changes yourself.  I am mostly going to use this in reference to my PR review, and it was easier for me to grok the failures this way.


Links
-----

* Original PR:  https://github.com/ManageIQ/manageiq/pull/18969