### PR TITLE
Your wish is my command...

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
 
+  include AnsibleRunnerAuthTranslations
+
   def path
     configuration_script_source.path_to_playbook(name)
   end
@@ -46,10 +48,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
       :extra_vars               => options[:extra_vars].try(:to_json)
     }
 
-    %i(credential vault_credential cloud_credential network_credential).each do |credential|
-      cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(options[cred_sym]).native_ref if options[cred_sym].present?
-    end
+    translate_credentials!(options, :other_hash => params)
 
     params.compact
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < ::Job
   DEFAULT_EXECUTION_TTL = 10 # minutes
 
+  include AnsibleRunnerAuthTranslations
+
   # options are job table columns, including options column which is the playbook context info
   def self.create_job(options)
     super(name, options.with_indifferent_access)
@@ -33,15 +35,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
   rescue => err
     _log.log_backtrace(err)
     my_signal(minimize_indirect, :post_ansible_run, err.message, 'error')
-  end
-
-  def translate_credentials!(launch_options)
-    %i[credential vault_credential cloud_credential network_credential].each do |cred_type|
-      credential_id = launch_options.delete("#{cred_type}_id".to_sym)
-      next if credential_id.blank?
-
-      launch_options[cred_type] = Authentication.find(credential_id).native_ref
-    end
   end
 
   LAUNCH_OPTIONS_KEYS = %i[

--- a/app/models/mixins/ansible_runner_auth_translations.rb
+++ b/app/models/mixins/ansible_runner_auth_translations.rb
@@ -1,0 +1,21 @@
+module AnsibleRunnerAuthTranslations
+  AUTH_TYPES = %i[credential vault_credential cloud_credential network_credential]
+
+  module_function
+
+  # Translates options hash with credential_ids into auth
+  #
+  # @param [Hash] options Hash containing the credential_ids
+  # @param [Hash] other_hash (options) Data to be updated if differs from <options>
+  # @param [Boolean] mutate_options (false) If passed in option keys should be removed, set to true
+  #
+  def translate_credentials!(options, other_hash: nil, mutate_options: false)
+    other_hash ||= options
+
+    AUTH_TYPES.each do |credential|
+      credential_sym         = "#{credential}_id".to_sym
+      credential_id          = mutate_options ? options.delete(credential_sym) : options[credential_sym]
+      other_hash[credential] = Authentication.find(credential_id).native_ref if credential_id.present?
+    end
+  end
+end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -2,6 +2,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   before_destroy :check_retirement_potential, :prepend => true
   around_destroy :around_destroy_callback, :prepend => true
 
+  extend AnsibleRunnerAuthTranslations
+
   RETIREMENT_ENTRY_POINTS = {
     'yes_without_playbook' => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Basic_Resource',
     'no_without_playbook'  => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Basic_Resource_None',
@@ -105,10 +107,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       end.to_json
     end
 
-    %i(credential vault_credential cloud_credential network_credential).each do |credential|
-      cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(info[cred_sym]).native_ref if info[cred_sym]
-    end
+    translate_credentials!(params, :other_hash => info)
 
     [tower, params.compact]
   end


### PR DESCRIPTION
@carbonin As you requested :smile:

> This bit of code to translate the credentials is now in 4 places 😭 if any of you want to help me work out a way to DRY that up I'd be grateful.
>
> \- @carbonin (July 15, 2019)

DRYs up code for translating credentials.  Makes it as flexible as possible to fit into the multiple places it is being used.


Note:  commit is `[WIP]` until I can run specs for the previous areas of the code to confirm this at least works a little bit.


Links
-----

* Built on top of https://github.com/ManageIQ/manageiq/pull/18983